### PR TITLE
Added an option to skip valid includes check

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -290,7 +290,7 @@ module JSONAPI
       #
       fields = {}
       # Normalize fields to accept a comma-separated string or an array of strings.
-      options[:fields].map do |type, whitelisted_fields|
+      options[:fields].each do |type, whitelisted_fields|
         whitelisted_fields = [whitelisted_fields] if whitelisted_fields.is_a?(Symbol)
         whitelisted_fields = whitelisted_fields.split(',') if whitelisted_fields.is_a?(String)
         fields[type.to_s] = whitelisted_fields.map(&:to_sym)


### PR DESCRIPTION
@mazaira , please take a look. It could be useful to add several includes for heterogeneous listing, like search results of different models, avoiding the validation of includes that are not valid for some models but are valid for others.